### PR TITLE
Add Fody/Costura so that dependent assemblies are merged into the EXE

### DIFF
--- a/Source/TailBlazer/FodyWeavers.xml
+++ b/Source/TailBlazer/FodyWeavers.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers>
+  <Costura CreateTemporaryAssemblies="false">
+    </Costura>
+  
+</Weavers>

--- a/Source/TailBlazer/Infrastucture/AppRegistry.cs
+++ b/Source/TailBlazer/Infrastucture/AppRegistry.cs
@@ -15,9 +15,16 @@ namespace TailBlazer.Infrastucture
             //set up logging
             string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "log4net.config");
             if (!File.Exists(path))
-                throw new FileNotFoundException("The log4net.config file was not found" + path);
-
-            log4net.Config.XmlConfigurator.ConfigureAndWatch(new FileInfo(path));
+            {
+                // should use the default config which is a resource
+                using (var stream = new MemoryStream(System.Text.Encoding.ASCII.GetBytes(TailBlazer.Properties.Resources.log4net)))
+                {
+                    log4net.Config.XmlConfigurator.Configure(stream);
+                }
+            }
+            else {
+                log4net.Config.XmlConfigurator.ConfigureAndWatch(new FileInfo(path));
+            }
             For<ILogger>().Use<Log4NetLogger>().Ctor<Type>("type").Is(x => x.ParentType).AlwaysUnique();
 
             For<ISelectionMonitor>().Use<SelectionMonitor>();

--- a/Source/TailBlazer/Properties/Resources.Designer.cs
+++ b/Source/TailBlazer/Properties/Resources.Designer.cs
@@ -59,5 +59,28 @@ namespace TailBlazer.Properties {
                 resourceCulture = value;
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;
+        ///&lt;configuration&gt;
+        ///&lt;log4net&gt;
+        ///&lt;appender name=&quot;OutputDebugStringAppender&quot; type=&quot;log4net.Appender.OutputDebugStringAppender&quot; &gt;
+        ///  &lt;layout type=&quot;log4net.Layout.PatternLayout&quot;&gt;
+        ///    &lt;conversionPattern value=&quot;[TailBlazer] %level %date{HH:mm:ss,fff} - %message%n&quot; /&gt;
+        ///  &lt;/layout&gt;
+        ///&lt;root&gt;
+        ///	&lt;level value=&quot;All&quot;/&gt;
+        ///&lt;appender-ref ref=&quot;OutputDebugStringAppender&quot;/&gt;
+        ///&lt;/root&gt;
+        ///&lt;/appender&gt;
+        ///&lt;/log4net&gt;
+        ///&lt;/configuration&gt;
+        ///.
+        /// </summary>
+        internal static string log4net {
+            get {
+                return ResourceManager.GetString("log4net", resourceCulture);
+            }
+        }
     }
 }

--- a/Source/TailBlazer/Properties/Resources.resx
+++ b/Source/TailBlazer/Properties/Resources.resx
@@ -46,7 +46,7 @@
     
     mimetype: application/x-microsoft.net.object.binary.base64
     value   : The object must be serialized with 
-            : System.Serialization.Formatters.Binary.BinaryFormatter
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
@@ -60,6 +60,7 @@
             : and then encoded with base64 encoding.
     -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>
         <xsd:choice maxOccurs="unbounded">
@@ -68,9 +69,10 @@
               <xsd:sequence>
                 <xsd:element name="value" type="xsd:string" minOccurs="0" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" />
+              <xsd:attribute name="name" use="required" type="xsd:string" />
               <xsd:attribute name="type" type="xsd:string" />
               <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="assembly">
@@ -85,9 +87,10 @@
                 <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
                 <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
               </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" msdata:Ordinal="1" />
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
               <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
               <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
             </xsd:complexType>
           </xsd:element>
           <xsd:element name="resheader">
@@ -109,9 +112,13 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="log4net" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>..\Resources\log4net.config;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;Windows-1252</value>
+  </data>
 </root>

--- a/Source/TailBlazer/Resources/log4net.config
+++ b/Source/TailBlazer/Resources/log4net.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+<log4net>
+<appender name="OutputDebugStringAppender" type="log4net.Appender.OutputDebugStringAppender" >
+  <layout type="log4net.Layout.PatternLayout">
+    <conversionPattern value="[TailBlazer] %level %date{HH:mm:ss,fff} - %message%n" />
+  </layout>
+<root>
+	<level value="All"/>
+<appender-ref ref="OutputDebugStringAppender"/>
+</root>
+</appender>
+</log4net>
+</configuration>

--- a/Source/TailBlazer/Resources/log4net.config
+++ b/Source/TailBlazer/Resources/log4net.config
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <configuration>
 <log4net>
-<appender name="OutputDebugStringAppender" type="log4net.Appender.OutputDebugStringAppender" >
+<appender name="DebugAppender" type="log4net.Appender.DebugAppender" >
   <layout type="log4net.Layout.PatternLayout">
     <conversionPattern value="[TailBlazer] %level %date{HH:mm:ss,fff} - %message%n" />
   </layout>
 <root>
 	<level value="All"/>
-<appender-ref ref="OutputDebugStringAppender"/>
+<appender-ref ref="DebugAppender"/>
 </root>
 </appender>
 </log4net>

--- a/Source/TailBlazer/TailBlazer.csproj
+++ b/Source/TailBlazer/TailBlazer.csproj
@@ -15,6 +15,8 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -272,6 +274,7 @@
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
     </None>
     <AppDesigner Include="Properties\" />
+    <None Include="Resources\log4net.config" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -285,7 +288,17 @@
   <ItemGroup>
     <Resource Include="tailblazer.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <Resource Include="FodyWeavers.xml" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Fody.1.28.3\build\Fody.targets" Condition="Exists('..\packages\Fody.1.28.3\build\Fody.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Fody.1.28.3\build\Fody.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Fody.1.28.3\build\Fody.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Source/TailBlazer/packages.config
+++ b/Source/TailBlazer/packages.config
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Costura.Fody" version="1.3.3.0" targetFramework="net45" developmentDependency="true" />
   <package id="Dragablz" version="0.0.2.143" targetFramework="net45" />
   <package id="DynamicData" version="4.3.1.1090" targetFramework="net46" />
+  <package id="Fody" version="1.28.3" targetFramework="net45" developmentDependency="true" />
   <package id="log4net" version="2.0.3" targetFramework="net46" />
   <package id="MahApps.Metro" version="1.1.3-ALPHA225" targetFramework="net46" />
   <package id="MaterialDesignColors" version="1.1.2" targetFramework="net45" />


### PR DESCRIPTION
As a result you can now just move the EXE around and it'll work. Makes it more convient to add to a toolbelt directory like 'util'.

Also added a default for log4net that will out put to win32 debug so you can use dbgview.

I think this makes it more utility like.