### PR TITLE
Fix need to Peek for StreamReaderExtended.Encoding

### DIFF
--- a/Source/TailBlazer.Domain/FileHandling/FileInfoEx.cs
+++ b/Source/TailBlazer.Domain/FileHandling/FileInfoEx.cs
@@ -68,7 +68,6 @@ namespace TailBlazer.Domain.FileHandling
             {
                 using (var reader = new StreamReaderExtended(stream, true))
                 {
-                    var something = reader.Peek();
                     return reader.CurrentEncoding;
                 }
             }


### PR DESCRIPTION
To get the encoding you needed to call `Peek` first from `StreamReaderExtended`. This seemed very fragile as you need to be aware of the implementation. I changed the property to be aware of the fact that the encoding is already detected. 

Ideally we would make the `CurrentEncoding` property a method to make this clearer, but I didn't want to go that far. 