### PR TITLE
Fix async methods returning void

### DIFF
--- a/Source/TailBlazer/Views/Searching/SearchOptionsProxy.cs
+++ b/Source/TailBlazer/Views/Searching/SearchOptionsProxy.cs
@@ -13,6 +13,7 @@ using TailBlazer.Domain.Formatting;
 using TailBlazer.Domain.Infrastructure;
 using TailBlazer.Infrastucture;
 using Hue = TailBlazer.Domain.Formatting.Hue;
+using System.Threading.Tasks;
 
 namespace TailBlazer.Views.Searching
 {
@@ -68,7 +69,7 @@ namespace TailBlazer.Views.Searching
             Hues = colourProvider.Hues;
             HighlightHue = searchMetadata.HighlightHue;
 
-            ShowIconSelectorCommand = new Command(ShowIconSelector);
+            ShowIconSelectorCommand = new Command(async () => await ShowIconSelector());
             RemoveCommand = new Command(() => removeAction(searchMetadata));
             HighlightCommand = new Command<Hue>(newHue =>
             {
@@ -88,10 +89,11 @@ namespace TailBlazer.Views.Searching
 
             _cleanUp = new CompositeDisposable(IconSelector,Foreground,Background, defaultHue.Connect());
         }
-        
-        private async void ShowIconSelector()
+
+        private async Task ShowIconSelector()
         {
             var dialogResult = await DialogHost.Show(IconSelector, ParentId);
+
             var result = (IconSelectorResult)dialogResult;
             if (result == IconSelectorResult.UseDefault)
             {
@@ -103,8 +105,8 @@ namespace TailBlazer.Views.Searching
             {
                 IconKind = IconSelector.Selected.Type;
             }
-         }
-        
+        }
+
         public PackIconKind IconKind
         {
             get { return _iconKind; }

--- a/Source/TailBlazer/Views/Tail/TailViewModel.cs
+++ b/Source/TailBlazer/Views/Tail/TailViewModel.cs
@@ -20,6 +20,7 @@ using TailBlazer.Domain.StateHandling;
 using TailBlazer.Infrastucture;
 using TailBlazer.Infrastucture.Virtualisation;
 using TailBlazer.Views.Searching;
+using System.Threading.Tasks;
 
 namespace TailBlazer.Views.Tail
 {
@@ -61,7 +62,7 @@ namespace TailBlazer.Views.Tail
         public ICommand OpenFileCommand { get; }
         public ICommand OpenFolderCommand { get; }
         public ICommand CopyPathToClipboardCommand { get; }
-        public ICommand OpenSearchOptionsCommand => new Command(OpenSearchOptions);
+        public ICommand OpenSearchOptionsCommand => new Command(async () => await OpenSearchOptions());
         public ICommand ClearCommand { get; }
         public ICommand UnClearCommand { get; }
         public ICommand KeyAutoTail { get; }
@@ -240,7 +241,7 @@ namespace TailBlazer.Views.Tail
      
         public TextScrollDelegate HorizonalScrollChanged { get; }
         
-        private async void OpenSearchOptions()
+        private async Task OpenSearchOptions()
         {
            await DialogHost.Show(SearchOptions, Id);
         }


### PR DESCRIPTION
Although it is allowed to return void with an async method it is
probably better to return a Task and make the Command<T> handle the
async nature.

As far as I know you are only allowed to return void in eventhandlers. 