### PR TITLE
Fix disconnect the executable from console

### DIFF
--- a/Source/TailBlazer/BootStrap.cs
+++ b/Source/TailBlazer/BootStrap.cs
@@ -4,17 +4,21 @@ using System.Windows.Threading;
 using StructureMap;
 using TailBlazer.Infrastucture;
 using TailBlazer.Infrastucture.AppState;
-using TailBlazer.Views;
 using TailBlazer.Views.Layout;
 using TailBlazer.Views.WindowManagement;
+using System.Runtime.InteropServices;
 
 namespace TailBlazer
 {
     public class BootStrap
     {
+        [DllImport("kernel32.dll", SetLastError = true)]
+        private static extern bool FreeConsole();
+
         [STAThread]
         public static void Main(string[] args)
         {
+            FreeConsole();
 
             var app = new App { ShutdownMode = ShutdownMode.OnLastWindowClose };
             app.InitializeComponent();
@@ -36,7 +40,5 @@ namespace TailBlazer
             window.Show();
             app.Run();
         }
-
-
     }
 }


### PR DESCRIPTION
When starting a C# windows application from console the
console window stays open. This patch fixes that by calling
the FreeConsole winapi.