### PR TITLE
Colour improvement

### DIFF
--- a/Source/TailBlazer.Fixtures/ColourProviderFixture.cs
+++ b/Source/TailBlazer.Fixtures/ColourProviderFixture.cs
@@ -1,0 +1,86 @@
+﻿using Xunit;
+using FluentAssertions;
+using TailBlazer.Views.Formatting;
+using TailBlazer.Domain.Formatting;
+using System.Linq;
+using System;
+
+namespace TailBlazer.Fixtures
+{
+    public class ColourProviderFixture
+    {
+        [Fact]
+        public void ColourProviderLookupShouldFindAHue()
+        {
+            var provider = new ColourProvider();
+            var key = new HueKey("amber", "Accent100");
+
+            var result = provider.Lookup(key);
+
+            result.HasValue.Should().Be(true);
+            result.Value.Key.Should().Be(key);
+        }
+
+        [Fact]
+        public void ColourProviderLookupWithIncorrectKeyShouldReturnEmptyValue()
+        {
+            var provider = new ColourProvider();
+            var key = new HueKey("xxxxxxxx", "yyyyyyyyyy");
+
+            var result = provider.Lookup(key);
+
+            result.HasValue.Should().Be(false);
+        }
+
+        [Fact]
+        public void ColourProviderLookupWithNullKeyShouldReturnEmptyValue()
+        {
+            var provider = new ColourProvider();
+            HueKey key; 
+            var result = provider.Lookup(key);
+
+            result.HasValue.Should().Be(false);
+        }
+
+        [Fact]
+        public void ColourProviderHuesShouldNotBeEmpty()
+        {
+            var provider = new ColourProvider();
+
+            var result = provider.Hues;
+
+            result.Any().Should().BeTrue();
+        }
+
+        [Fact]
+        public void ColourProviderLookupShouldFindAllHues()
+        {
+            var provider = new ColourProvider();
+
+            foreach (var hue in provider.Hues)
+            {
+                provider.Lookup(hue.Key).HasValue.Should().BeTrue();
+            }
+        }
+
+        [Fact]
+        public void ColourProviderGetAccentShouldSupportAllThemes()
+        {
+            var provider = new ColourProvider();
+
+            foreach (var theme in Enum.GetValues(typeof(Theme)))
+            {
+                provider.GetAccent((Theme)theme).Should().NotBeNull();
+            }
+        }
+
+        [Fact]
+        public void ColourProviderDefaultAccentShouldReturnSomething()
+        {
+            var provider = new ColourProvider();
+
+            provider.DefaultAccent.Should().NotBeNull();
+        }
+
+    }
+}

--- a/Source/TailBlazer.Fixtures/DefaultColourSelectorFixture.cs
+++ b/Source/TailBlazer.Fixtures/DefaultColourSelectorFixture.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using Xunit;
+using FluentAssertions;
+using TailBlazer.Views.Formatting;
+
+namespace TailBlazer.Fixtures
+{
+    public class DefaultColourSelectorFixture
+    {
+        [Fact]
+        public void DefaultColourSelectorLookupShouldWork()
+        {
+            var provider = new ColourProvider();
+            var selector = new DefaultColourSelector(provider);
+            var key = provider.Hues.First().Key;
+
+            var result = selector.Lookup(key);
+
+            result.Key.Should().Be(key);
+        }
+
+        [Fact]
+        public void DefaultColourSelectorSelectShouldWork()
+        {
+            var provider = new ColourProvider();
+            var selector = new DefaultColourSelector(provider);
+
+            var result = selector.Select("DEBUG");
+
+            result.Should().NotBeNull();
+        }
+    }
+}

--- a/Source/TailBlazer.Fixtures/TailBlazer.Fixtures.csproj
+++ b/Source/TailBlazer.Fixtures/TailBlazer.Fixtures.csproj
@@ -100,6 +100,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ColourProviderFixture.cs" />
+    <Compile Include="DefaultColourSelectorFixture.cs" />
     <Compile Include="DisplayTextFixture.cs" />
     <Compile Include="FileDropFixture.cs" />
     <Compile Include="StartFromFixture.cs" />

--- a/Source/TailBlazer.Fixtures/TailBlazer.Fixtures.csproj
+++ b/Source/TailBlazer.Fixtures/TailBlazer.Fixtures.csproj
@@ -99,6 +99,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ColourProviderFixture.cs" />
     <Compile Include="DisplayTextFixture.cs" />
     <Compile Include="FileDropFixture.cs" />
     <Compile Include="StartFromFixture.cs" />

--- a/Source/TailBlazer/Views/Formatting/ColourProvider.cs
+++ b/Source/TailBlazer/Views/Formatting/ColourProvider.cs
@@ -45,6 +45,9 @@ namespace TailBlazer.Views.Formatting
 
         public Optional<Hue> Lookup(HueKey key)
         {
+            if (null == key.Name || null == key.Swatch)
+                return new Optional<Hue>();
+
             return HueCache.Lookup(key);
         }
 

--- a/Source/TailBlazer/Views/Formatting/DefaultColourSelector.cs
+++ b/Source/TailBlazer/Views/Formatting/DefaultColourSelector.cs
@@ -11,14 +11,11 @@ namespace TailBlazer.Views.Formatting
     public sealed class DefaultColourSelector : IDefaultColourSelector
     {
         private readonly IColourProvider _colourProvider;
-        private readonly Dictionary<HueKey, Hue> _hues;
-      //  private readonly Hue _defaultHighlight;
         private readonly DefaultHue[] _defaults;
 
         public DefaultColourSelector(IColourProvider colourProvider)
         {
             _colourProvider = colourProvider;
-            _hues = colourProvider.Hues.ToDictionary(h => h.Key);
             _defaults = Load().ToArray();
         }
         
@@ -34,7 +31,7 @@ namespace TailBlazer.Views.Formatting
 
         public Hue Lookup(HueKey key)
         {
-            return _hues.Lookup(key).ValueOr(() => _colourProvider.DefaultAccent);
+            return _colourProvider.Lookup(key).ValueOr(() => _colourProvider.DefaultAccent);
         }
 
         private IEnumerable<DefaultHue> Load()
@@ -50,7 +47,7 @@ namespace TailBlazer.Views.Formatting
 
         private Hue Lookup(string swatch, string name)
         {
-            return _hues.Lookup(new HueKey(swatch, name))
+            return _colourProvider.Lookup(new HueKey(swatch, name))
                 .ValueOrThrow(() => new MissingKeyException(swatch + "."+ name + " is invalid"));
         }
 
@@ -60,14 +57,12 @@ namespace TailBlazer.Views.Formatting
             public Hue Hue { get; }
             public bool MatchTextOnCase { get; }
 
-
             public DefaultHue(string text, Hue hue, bool matchTextOnCase = false)
             {
                 Text = text;
                 Hue = hue;
                 MatchTextOnCase = matchTextOnCase;
             }
-
         }
     }
 }


### PR DESCRIPTION
The contents of the Hues Dictionary got deep copied into the `DefaultColourSelector` class. This can be avoided by calling `Lookup()` from `ColourProvider`.