### PR TITLE
Fixed #128

### DIFF
--- a/Source/TailBlazer/Views/Layout/LayoutConverter.cs
+++ b/Source/TailBlazer/Views/Layout/LayoutConverter.cs
@@ -224,6 +224,7 @@ namespace TailBlazer.Views.Layout
         {
             return GetChildrenState(element)
                 .AsParallel()
+                .AsOrdered()
                 .Select(state =>
                 {
                     var key = state.Key;


### PR DESCRIPTION
The problem here is that `.AsParallel` doesn't preserve order. We could either remove that line or add `.AsOrdered`. I tested both with restoring 100 files, the former averaged 1300 ms and the latter (commited) approach averaged 900 ms.