### PR TITLE
Fix 2 bugs on search feature

### DIFF
--- a/Source/TailBlazer.Domain/FileHandling/Search/SearchMetadataFactory.cs
+++ b/Source/TailBlazer.Domain/FileHandling/Search/SearchMetadataFactory.cs
@@ -23,9 +23,13 @@ namespace TailBlazer.Domain.FileHandling.Search
         {
             if (searchText == null) throw new ArgumentNullException(nameof(searchText));
 
-            var withNegation = searchText.WithNegation();
-            var isExclusion = withNegation.IsNegation;
-            searchText = withNegation.Text;
+            var isExclusion = false;
+            if (!useRegex)
+            {
+                var withNegation = searchText.WithNegation();
+                isExclusion = withNegation.IsNegation;
+                searchText = withNegation.Text;
+            }
 
             var association = _textAssociationCollection.Lookup(searchText);
             string icon;
@@ -52,6 +56,5 @@ namespace TailBlazer.Domain.FileHandling.Search
                 isGlobal,
                 isExclusion);
         }
-
     }
 }

--- a/Source/TailBlazer.Fixtures/SearchHintEx.cs
+++ b/Source/TailBlazer.Fixtures/SearchHintEx.cs
@@ -1,0 +1,120 @@
+using FluentAssertions;
+using TailBlazer.Domain.FileHandling.Recent;
+using Xunit;
+using TailBlazer.Views.Searching;
+
+namespace TailBlazer.Fixtures
+{
+    public class SearchHintEx
+    {
+        [Fact]
+        public void ShouldAskForTextWhenTextIsEmpty()
+        {
+            var searchRequest = new SearchRequest("", false);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeTrue();
+            result.Message.Should().Be("Type to search using plain text");
+        }
+
+        [Fact]
+        public void ShouldAskForTextWhenRegexIsEmpty()
+        {
+            var searchRequest = new SearchRequest("", true);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeTrue();
+            result.Message.Should().Be("Type to search using regex");
+        }
+
+        [Fact]
+        public void ShouldBeValidWhenSearchingPlainText()
+        {
+            var searchRequest = new SearchRequest("[inf", false);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeTrue();
+            result.Message.Should().Be("Hit enter to search using plain text");
+        }
+
+        [Fact]
+        public void ShouldBeValidWhenSearchingAValidRegex()
+        {
+            var searchRequest = new SearchRequest("[inf]", true);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeTrue();
+            result.Message.Should().Be("Hit enter to search using regex");
+        }
+
+        [Fact]
+        public void ShouldBeInvalidWhenSearchingTooShortRegEx()
+        {
+            var searchRequest = new SearchRequest(".", true);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeFalse();
+            result.Message.Should().Be("Regex must be at least 2 characters");
+        }
+
+        [Fact]
+        public void ShouldBeValidWhenSearchingPlainTextExclusion()
+        {
+            var searchRequest = new SearchRequest("-[inf", false);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeTrue();
+            result.Message.Should().Be("Hit enter to search using plain text");
+        }
+
+        [Fact]
+        public void ShouldBeInvalidWhenPlainTextExclusionTextIsTooShort()
+        {
+            var searchRequest = new SearchRequest("-f", false);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeFalse();
+            result.Message.Should().Be("Text must be at least 3 characters");
+        }
+
+        [Fact]
+        public void ShouldBeInvalidWhenSearchingIrregularRegEx()
+        {
+            var searchRequest = new SearchRequest("[inf", true);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeFalse();
+            result.Message.Should().Be("Invalid regular expression");
+        }
+
+        [Fact]
+        public void ShouldBeInvalidWhenPlainTextContainsIllegalCharacter()
+        {
+            var searchRequest = new SearchRequest(@"[i\nf", false);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeFalse();
+            result.Message.Should().Be("Text contains illegal characters");
+        }
+
+        [Fact]
+        public void ShouldBeInvalidWhenPlainTextContainsOnlyWhiteSpaces()
+        {
+            var searchRequest = new SearchRequest("-    \t", false);
+
+            var result = searchRequest.BuildMessage();
+
+            result.IsValid.Should().BeFalse();
+            result.Message.Should().Be("Text contains illegal characters");
+        }
+    }
+}

--- a/Source/TailBlazer.Fixtures/TailBlazer.Fixtures.csproj
+++ b/Source/TailBlazer.Fixtures/TailBlazer.Fixtures.csproj
@@ -119,6 +119,7 @@
     <Compile Include="FileDropFixture.cs" />
     <Compile Include="IconDescriptionFixture.cs" />
     <Compile Include="IconProviderFixture.cs" />
+    <Compile Include="SearchHintEx.cs" />
     <Compile Include="StartFromFixture.cs" />
     <Compile Include="FileSearchFixture.cs" />
     <Compile Include="FileSegmentFixture.cs" />

--- a/Source/TailBlazer/Views/Searching/SearchHintEx.cs
+++ b/Source/TailBlazer/Views/Searching/SearchHintEx.cs
@@ -24,7 +24,7 @@ namespace TailBlazer.Views.Searching
             {
                 try
                 {
-                    var test = new Regex(source.TextWithoutExclusion);
+                    var test = new Regex(source.Text);
                 }
                 catch (Exception)
                 {

--- a/Source/TailBlazer/Views/Searching/SearchHintEx.cs
+++ b/Source/TailBlazer/Views/Searching/SearchHintEx.cs
@@ -20,13 +20,16 @@ namespace TailBlazer.Views.Searching
             if ((!source.UseRegEx && source.Text.Contains(@"\")) || (source.TextWithoutExclusion.Trim().Length == 0))
                 return new SearchHintMessage(false, "Text contains illegal characters");
 
-            try
+            if (source.UseRegEx)
             {
-                var test = new Regex(source.TextWithoutExclusion);
-            }
-            catch (Exception)
-            {
-                return new SearchHintMessage(false, "Invalid regular expression");
+                try
+                {
+                    var test = new Regex(source.TextWithoutExclusion);
+                }
+                catch (Exception)
+                {
+                    return new SearchHintMessage(false, "Invalid regular expression");
+                }
             }
             
             var message = $"Hit enter to search using {(source.UseRegEx ? "regex" : "plain text")}";


### PR DESCRIPTION
* unable to search in plain text something detected by TrailBlazer as a Regex (even after clicking on the button to search in plain text)
* searching with a regex beginning with '-' (like '-\d{2}', to search part of a date) put TrailBalzer in a (really) broken state

For the first fix, that put under the light another bug that is out of my skills to fix :( The text and the textbox color are of the wrong color, like you could see on the image.
![2016-09-26 23_55_23-tail blazer](https://cloud.githubusercontent.com/assets/460196/18853334/dfd32b0c-8444-11e6-924e-f217bd4e962a.png)
Way to reproduce:
1. Enter a text that TailBlazer analyse as an invalid regex (ex: [Info)
2. Click on the button to switch to a plain text search
3. You should see the text change to tell that the text is valid but the colors remain the sames

